### PR TITLE
AI검색 로직 개선

### DIFF
--- a/ai/src/pricing_model.py
+++ b/ai/src/pricing_model.py
@@ -41,7 +41,6 @@ def multi_hot_encode_industry(df, industry_col="INDUSTRY", threshold=10):
             return ""
         tokens = [i.strip() for i in x.split(',')]
         processed_tokens = [i if frequency.get(i, 0) >= threshold else "Other" for i in tokens]
-        
         return ",".join(sorted(set(processed_tokens)))
     
     df[industry_col] = df[industry_col].apply(process_industries)

--- a/ai/src/pricing_model_test.py
+++ b/ai/src/pricing_model_test.py
@@ -5,6 +5,7 @@ import re
 import joblib
 import pandas as pd
 import numpy as np
+import difflib
 from datetime import datetime
 from konlpy.tag import Okt
 from sklearn.preprocessing import StandardScaler
@@ -41,6 +42,28 @@ except Exception as e:
     print(f"output_with_price_category.csv 로딩 실패: {e}")
     sys.exit(1)
 
+def extract_tokens(text: str) -> list:
+    return re.findall(r'[\w가-힣]+', text.lower())
+
+def contains_query_tokens(candidate: str, query: str) -> bool:
+    candidate_tokens = extract_tokens(candidate)
+    query_tokens = extract_tokens(query)
+    return all(any(q in ct for ct in candidate_tokens) for q in query_tokens)
+
+def fuzzy_ratio(query: str, title: str) -> float:
+    query_norm = "".join(extract_tokens(query))
+    title_norm = "".join(extract_tokens(title))
+    return difflib.SequenceMatcher(None, query_norm, title_norm).ratio()
+
+def hybrid_title_search(query: str, df: pd.DataFrame, title_col="TITLE") -> pd.DataFrame:
+    candidates = df[df[title_col].apply(lambda x: contains_query_tokens(x, query))]
+    if candidates.empty:
+        return None
+    candidates = candidates.copy()
+    candidates["fuzzy_score"] = candidates[title_col].apply(lambda x: fuzzy_ratio(query, x))
+    candidates.sort_values("fuzzy_score", ascending=False, inplace=True)
+    return candidates
+
 def multi_hot_encode_industry(industry_str, all_inds):
     row_dict = {}
     inds = [i.strip() for i in str(industry_str).split(',') if i.strip()]
@@ -55,28 +78,35 @@ def preprocess_title(text):
         return ""
     okt = Okt()
     tokens = okt.morphs(text)
-    stopwords = ["의", "가", "이", "은", "들", "는", "좀", "잘", "걍", "과", "도", "를", "으로", "자", "에", "와", "한", "하다"]
+    stopwords = {"의", "가", "이", "은", "들", "는", "좀", "잘", "걍", "과", "도", "를", "으로", "자", "에", "와", "한", "하다"}
     tokens = [token for token in tokens if token not in stopwords]
     return " ".join(tokens)
 
 def prepare_input_from_product(product_json: dict) -> pd.DataFrame:
     full_title = str(product_json.get("name", "UNKNOWN")).strip()
     
-    matched = df_main[df_main["TITLE"].str.contains(full_title, na=False)]
-    if not matched.empty:
-        category_str = matched.iloc[0]["CATEGORY"]
-        industry_str = str(matched.iloc[0].get("INDUSTRY", "기타"))
-        popularity_score = matched.iloc[0].get("POPULARITY_SCORE", 0)
-        category_pop_score = matched.iloc[0].get("CATEGORY_POPULARITY_SCORE", 0)
-        price_category_val = str(matched.iloc[0].get("PRICE_CATEGORY", "Mid"))
+    candidates = hybrid_title_search(full_title, df_main, title_col="TITLE")
+    if candidates is not None and not candidates.empty:
+        print("검색된 후보 목록:")
+        for idx, row in candidates.iterrows():
+            print(f"  - {row['TITLE']} (유사도: {fuzzy_ratio(full_title, row['TITLE']):.2f})")
+        best_candidate = candidates.iloc[0] 
+    else:
+        best_candidate = None
+        print("일치하는 후보를 찾지 못했습니다. 기본값 사용합니다.")
+
+    if best_candidate is not None:
+        category_str = best_candidate["CATEGORY"]
+        industry_str = str(best_candidate.get("INDUSTRY", "기타"))
+        popularity_score = best_candidate.get("POPULARITY_SCORE", 0)
+        category_pop_score = best_candidate.get("CATEGORY_POPULARITY_SCORE", 0)
+        price_category_val = str(best_candidate.get("PRICE_CATEGORY", "Mid"))
     else:
         category_str = full_title  
         industry_str = "기타"
         popularity_score = 0
         category_pop_score = 0
         price_category_val = "Mid"
-    
-    print(f"검색된 업종: {industry_str}")
     
     industry_encoded = multi_hot_encode_industry(industry_str, all_industries)
     


### PR DESCRIPTION
## 요약 Summary

- **검색어 전처리 및 정규화 개선(토큰 기반 전처리 및 추출 -> 예: "아이폰 16프로 자급제" → ['아이폰', '16프로', '자급제'])**

- **하이브리드 검색 로직**
검색어의 각 토큰이 후보 제목의 추출된 토큰 중 어느 하나에라도 부분 문자열로 포함되어 있으면 매칭되도록 구현.
예를 들어, 검색어 "아이폰 16프로 자급제"에서 추출된 토큰 ['아이폰', '16프로', '자급제']가 후보 제목 "아이폰16프로 512기가 화이트티타늄 3일사용 자급제 ..."의 토큰들 내에서 각각 부분적으로라도 나타나면 해당 후보로 인정함.
+유사도 비교  difflib을 사용하여 정규화된 문자열 간 유사도를 계산함. 이를 통해 후보들 사이의 유사도를 수치로 평가하여, 가장 유사한 후보를 선택

- **검색 속도 개선( 정규화된 문자열 비교 방식(벡터화된 str.contains)을 사용하여 검색 후보를 효율적으로 추출)**

**[예시 이미지]**
![image](https://github.com/user-attachments/assets/78ba5106-34dc-4f03-8b7e-f456ca4ae718)

## 테스트 방법 How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

## 추가 작업 To-Do
